### PR TITLE
Support conversion during Edit Mode

### DIFF
--- a/Core/Core/Utilties/AuthoringUtilities.cs
+++ b/Core/Core/Utilties/AuthoringUtilities.cs
@@ -18,7 +18,7 @@ namespace Latios
                 Object.DestroyImmediate(obj);
             }
 #else
-            Object.Destroy(go);
+            Object.Destroy(obj);
 #endif
         }
     }

--- a/Core/Core/Utilties/AuthoringUtilities.cs
+++ b/Core/Core/Utilties/AuthoringUtilities.cs
@@ -1,0 +1,25 @@
+﻿using System.Runtime.CompilerServices;
+using UnityEngine;
+
+namespace Latios
+{
+    public static class AuthoringUtilities
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void DestroySafe(this Object obj)
+        {
+#if UNITY_EDITOR
+            if (Application.isPlaying)
+            {
+                Object.Destroy(obj);
+            }
+            else
+            {
+                Object.DestroyImmediate(obj);
+            }
+#else
+            Object.Destroy(go);
+#endif
+        }
+    }
+}

--- a/Core/Core/Utilties/AuthoringUtilities.cs.meta
+++ b/Core/Core/Utilties/AuthoringUtilities.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9b2290dbad2c446d9284a038cb5adee9
+timeCreated: 1661094427

--- a/Kinemation/Authoring/ConversionContextComponents.cs
+++ b/Kinemation/Authoring/ConversionContextComponents.cs
@@ -31,7 +31,7 @@ namespace Latios.Kinemation.Authoring
         {
             if (m_shadowHierarchy != null)
             {
-                GameObject.Destroy(m_shadowHierarchy);
+                m_shadowHierarchy.DestroySafe();
             }
         }
     }

--- a/MyriAudio/Authoring/ListenerProfileSmartBlobberSystem.cs
+++ b/MyriAudio/Authoring/ListenerProfileSmartBlobberSystem.cs
@@ -56,7 +56,7 @@ namespace Latios.Myri.Authoring.Systems
 
         protected override void OnDestroy()
         {
-            Object.Destroy(m_defaultProfile);
+            m_defaultProfile.DestroySafe();
             base.OnDestroy();
         }
 


### PR DESCRIPTION
When writing automated tests for DMotion, I found that the Latios conversion workflow does not work outside playmode, due to the use of `Object.Destroy`.

![image](https://user-images.githubusercontent.com/15620434/185797917-6a50b05c-5c0b-453d-a7e9-ee85bb892465.png)

This PR fixes it, by creating a utility function `AuthoringUtilities.DestroySafe`, which correctly handles destroying in Edit Mode, and should resolve to `Object.Destroy` in a compiled build.

![image](https://user-images.githubusercontent.com/15620434/185797991-cb0dff1f-5ddd-465d-885b-17741492c39a.png)
