### PR TITLE
Psyshock bug fixes + access to Bodies on CollisionLayer

### DIFF
--- a/Core/Systems/_Essentials/LatiosWorldUnmanagedSystem.cs
+++ b/Core/Systems/_Essentials/LatiosWorldUnmanagedSystem.cs
@@ -111,7 +111,10 @@ namespace Latios.Systems
         {
             m_impl->m_worldUnmanaged.EntityManager.CompleteAllTrackedJobs();
 
-            (m_impl->m_managedStructStorage.Target as ManagedStructComponentStorage).Dispose();
+            if (m_impl->m_managedStructStorage.IsAllocated)
+            {
+                (m_impl->m_managedStructStorage.Target as ManagedStructComponentStorage)?.Dispose();
+            }
             m_impl->m_collectionComponentStorage.Dispose();
             m_impl->m_collectionDependencies.Dispose();
             m_impl->m_executingSystemStack.Dispose();

--- a/PsyshockPhysics/Physics/Authoring/ConvexColliderSmartBlobberSystem.cs
+++ b/PsyshockPhysics/Physics/Authoring/ConvexColliderSmartBlobberSystem.cs
@@ -137,7 +137,7 @@ namespace Latios.Psyshock.Authoring.Systems
                 }
             }).Schedule();
 
-            Entities.ForEach((ref SmartBlobberResult result, in ConvexColliderBlobBakeData data) =>
+            Entities.WithReadOnly(hashmap).ForEach((ref SmartBlobberResult result, in ConvexColliderBlobBakeData data) =>
             {
                 result.blob = UnsafeUntypedBlobAssetReference.Create(hashmap[data.mesh.GetInstanceID()].blob);
             }).ScheduleParallel();

--- a/PsyshockPhysics/Physics/Types/CollisionLayer.cs
+++ b/PsyshockPhysics/Physics/Types/CollisionLayer.cs
@@ -63,6 +63,8 @@ namespace Latios.Psyshock
         internal int3                                                                worldSubdivisionsPerAxis;
         AllocatorManager.AllocatorHandle                                             allocator;
 
+        public NativeArray<ColliderBody> Bodies => bodies;
+
         internal CollisionLayer(int bodyCount, CollisionLayerSettings settings, AllocatorManager.AllocatorHandle allocator)
         {
             worldMin                 = settings.worldAabb.min;

--- a/PsyshockPhysics/Physics/Types/PhysicsComponentLookup.cs
+++ b/PsyshockPhysics/Physics/Types/PhysicsComponentLookup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
@@ -90,6 +91,18 @@ namespace Latios.Psyshock
         public static implicit operator PhysicsComponentLookup<T>(ComponentLookup<T> componentDataFromEntity)
         {
             return new PhysicsComponentLookup<T> { lookup = componentDataFromEntity };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Update(ref SystemState state)
+        {
+            lookup.Update(ref state);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Update(SystemBase system)
+        {
+            lookup.Update(system);
         }
 
         [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]


### PR DESCRIPTION
This PR fixes 3 bugs + adds an accessor to the bodies array in `CollisionLayer`. This last change you may not want/need, given it seems you already exposed some of this code by your devlogs.

Bug fixes:

- **Add update method to physics lookup**: This avoids the warning that comes with creating ComponentLookup every frame
- **Create accessor to CollisionLayer.Bodies**: This is the optional change. Needed this for my CharacterController. 
- **Prevent Handle is not allocated exception**: This fixes a bug with Latios World bootstrap. It can be reproducied by creating an empty project and creating a LatiosBootstrap with any workflow.
- **Fix hashmap is not readonly exception**: Fix safety related exception related to hashmap not being marked as readonly.