### PR TITLE
Update DynamicHashMap.cs

### DIFF
--- a/Core/GameplayToolkit/DynamicHashMap.cs
+++ b/Core/GameplayToolkit/DynamicHashMap.cs
@@ -445,9 +445,9 @@ namespace Latios
 
                             // Start over
                             return TryAdd(in key, in value);
-                        }
-                        last.nextIndex              = 0;
+                        }                        
                         candidate.nextIndex         = m_buffer.Length;
+                        last.nextIndex              = 0;
                         m_buffer.Add(new Pair { key = key, value = value, meta = (uint)m_count | 0x10000000 });
                         IncrementCount();
                         return true;


### PR DESCRIPTION
CORE 
Fix for occasional out of range errors in DynamicHashMap
When 'last' is the same element as 'candidate' I believe nextIndex needs to be 0

## Contribution Standard Info

Thanks for contributing!

If you are contributing to an “Open Project” such as LSSS, ATAR, or Free
Parking, and did NOT make any modifications to the framework files, skip this
section and move on to *Details*.

### Base of Changes

*If this is a pull request into the Latios Framework repository, specify the
project and commit your changes are most closely based on. For “Open Project”
commits, specify the commit hash or link. For framework commits, specify the
version or commit name.*

### Review Items

*If you simply want to get things merged, leave these unchecked. If you would
like to learn and improve, add checkmarks to the following you’d like feedback
on. Things you leave unchecked may be corrected after this pull request is
merged.*

- [ ] Regression concerns

- [ ] Functional correctness (code-read only)

- [ ] Use-case flexibility

- [ ] Performance considerations

- [ ] Naming, comprehension, and code aesthetic (aside from white-space)

### Preferred Contributor Name and Shoutouts

*If you are not already on the Latios Framework README contributor list or would
like to change the name used, specify it here. Additionally, if you would like
to add a project of yours to the README, you may also specify it here.*

*If this is a pull request into an Open Project repo, please specify your GitHub
contributor email here so that you will be recorded in the commit history of the
official framework repository.

## Details

CORE 
Fix for occasional out of range errors in DynamicHashMap
When 'last' is the same element as 'candidate' I believe nextIndex needs to be 0