### PR TITLE
add `Shader Graph` to dependencies in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "com.unity.entities": "1.2.1",
     "com.unity.audio.dspgraph": "0.1.0-preview.22",
     "com.unity.entities.graphics": "1.2.1",
-    "com.unity.burst": "1.8.12"
+    "com.unity.burst": "1.8.12",
+    "com.unity.shadergraph": "14.0.11"
   },
   "unityRelease": "13f1",
   "keywords": [


### PR DESCRIPTION
## Details

new empty project, and the following error appears.
`shader graph` package is missing.
![image](https://github.com/user-attachments/assets/26da4b91-9256-4811-b873-2df5a2ca50c3)
