### PR TITLE
Add support for focusing runtime entities, fix focus for baked entities

### DIFF
--- a/Kinemation/Editor/Latios.Kinemation.Editor.asmdef
+++ b/Kinemation/Editor/Latios.Kinemation.Editor.asmdef
@@ -11,7 +11,8 @@
         "GUID:e04e6c86a9f3947eb95fded39f9e60cc",
         "GUID:7a450cf7ca9694b5a8bfa3fd83ec635a",
         "GUID:59e15be979a1f934cac2dcd97dd0ea2b",
-        "GUID:c38fb62397af04c51b143415e1db6d90"
+        "GUID:c38fb62397af04c51b143415e1db6d90",
+        "GUID:46fe9b4ef94d76744bc0b97bc2f73d94"
     ],
     "includePlatforms": [
         "Editor"

--- a/Kinemation/Editor/Latios.Kinemation.Editor.asmdef
+++ b/Kinemation/Editor/Latios.Kinemation.Editor.asmdef
@@ -7,7 +7,11 @@
         "GUID:42b38659db4a3c64590f6c8e31576389",
         "GUID:d8b63aba1907145bea998dd612889d6b",
         "GUID:e0cd26848372d4e5c891c569017e11f1",
-        "GUID:d5b6d673878904c4e86229129b6086a2"
+        "GUID:d5b6d673878904c4e86229129b6086a2",
+        "GUID:e04e6c86a9f3947eb95fded39f9e60cc",
+        "GUID:7a450cf7ca9694b5a8bfa3fd83ec635a",
+        "GUID:59e15be979a1f934cac2dcd97dd0ea2b",
+        "GUID:c38fb62397af04c51b143415e1db6d90"
     ],
     "includePlatforms": [
         "Editor"

--- a/Kinemation/Editor/RuntimeEntitySceneViewFocus.cs
+++ b/Kinemation/Editor/RuntimeEntitySceneViewFocus.cs
@@ -1,0 +1,104 @@
+﻿using Latios.Transforms.Abstract;
+using Unity.Entities;
+using Unity.Entities.Editor;
+using Unity.Rendering;
+using UnityEditor;
+using UnityEngine;
+
+namespace Latios.Kinemation.Editor
+{
+    static class RuntimeEntitySceneViewFocus
+    {
+        private static Entity _lockedEntity;
+
+        [UnityEditor.Callbacks.DidReloadScripts]
+        private static void ScriptsHasBeenReloaded()
+        {
+            SceneView.duringSceneGui   += DuringSceneGui;
+            Selection.selectionChanged += SelectionChanged;
+        }
+
+        private static EntitySelectionProxy GetCurrentSelectionProxy()
+        {
+            if (Selection.objects.Length != 1) return null;
+
+            // If a Runtime entity is selected, objects[0] will be EntitySelectionProxy. If a baked entity is selected, objects[0] will be a GO
+            // and activeContext will contain the EntitySelectionProxy
+            if (Selection.objects[0] is EntitySelectionProxy objProxy)
+            {
+                return objProxy;
+            }
+
+            if (Selection.activeContext is EntitySelectionProxy ctxProxy)
+            {
+                return ctxProxy;
+            }
+
+            return null;
+        }
+
+        private static void SelectionChanged()
+        {
+            if (_lockedEntity == default) return;
+
+            if (GetCurrentSelectionProxy()?.Entity != _lockedEntity)
+                _lockedEntity = default;
+        }
+
+        private static void LookAtEntity(EntitySelectionProxy selectionProxy, SceneView sceneView)
+        {
+            var entity = selectionProxy.Entity;
+            var em     = selectionProxy.World.EntityManager;
+
+            if (!em.HasComponent(entity, QueryExtensions.GetAbstractWorldTransformROComponentType())) return;
+
+            Bounds bounds;
+            if (em.HasComponent<WorldRenderBounds>(entity))
+            {
+                var aabb = em.GetComponentData<WorldRenderBounds>(entity).Value;
+                bounds = new Bounds(aabb.Center, aabb.Size);
+            }
+            else
+            {
+                var t = em.GetAspect<WorldTransformReadOnlyAspect>(entity);
+                bounds = new Bounds(t.position, Vector3.one);
+            }
+
+            sceneView.LookAt(bounds.center, sceneView.rotation, sceneView.size);
+            sceneView.FixNegativeSize();
+        }
+
+        private static void DuringSceneGui(SceneView sceneView)
+        {
+            var ev = Event.current;
+
+            if (ev.type == EventType.ExecuteCommand) HandleExecuteCommand(sceneView);
+            if (ev.type == EventType.Repaint && _lockedEntity != default)
+                LookAtEntity(GetCurrentSelectionProxy(), sceneView);
+        }
+
+        private static void HandleExecuteCommand(SceneView sceneView)
+        {
+            var ev = Event.current;
+
+            var withLock = ev.commandName == "FrameSelectedWithLock";
+
+            if (ev.commandName != "FrameSelected" && !withLock) return;
+
+            EntitySelectionProxy selectionProxy = GetCurrentSelectionProxy();
+
+            if (!selectionProxy) return;
+
+            LookAtEntity(selectionProxy, sceneView);
+
+            if (withLock)
+            {
+                _lockedEntity = selectionProxy.Entity;
+            }
+
+            // consume the event
+            ev.Use();
+            ev.commandName = "";
+        }
+    }
+}

--- a/Kinemation/Editor/RuntimeEntitySceneViewFocus.cs.meta
+++ b/Kinemation/Editor/RuntimeEntitySceneViewFocus.cs.meta
@@ -1,0 +1,2 @@
+﻿fileFormatVersion: 2
+guid: 57089d651b5834d46b26e59ebc2e7801


### PR DESCRIPTION
### Base of Changes

0.12.0-beta8

### Review Items

- [x] Regression concerns

- [x] Functional correctness (code-read only)

- [x] Use-case flexibility

- [x] Performance considerations

- [x] Naming, comprehension, and code aesthetic (aside from white-space)

### Preferred Contributor Name and Shoutouts

github name is fine

## Details

When using QVVS or unity transforms and generating entities at runtime, with no baked gameobject counter-part, focusing on the selected entity in the hierarchy with the F shortcut didn't work. This is particularly annoying for procedurally generated entities. With a baked entity, focusing would take you to the GameObject position (origin of the entity), instead of the current transform position. This caused focus lock (shift + f) to not work and focus to be rather useless if your entities change position.

This PR fixes all those cases. When focusing a baked entity, the scene camera will focus on the current entity position according to its transform. Runtime only entities are also handled and focus and focus lock work on them now.

The packages added to the asmdef are: `Unity.Mathematics.Extensions` (For AABB), `Unity.Entities.Graphics` (For WorldRenderBounds), `Latios.Transforms`, `Unity.Entities.Editor` and `Latios.Core` (For LatiosWorld).