### PR TITLE
Kinemation: initialize optimized skeletons bound at the render sync point

### DIFF
--- a/Kinemation/Systems/KinemationSuperSystems.cs
+++ b/Kinemation/Systems/KinemationSuperSystems.cs
@@ -198,6 +198,9 @@ namespace Latios.Kinemation.Systems
             GetOrCreateAndAddUnmanagedSystem<LatiosUpdateEntitiesGraphicsChunkStructureSystem>();
             GetOrCreateAndAddUnmanagedSystem<LatiosAddWorldAndChunkRenderBoundsSystem>();
             GetOrCreateAndAddUnmanagedSystem<KinemationBindingReactiveSystem>();
+            // Expand the buffers of optimized skeletons first bound here (e.g. runtime-instantiated or netcode ghosts)
+            // before they are skinned; the frame sync point is followed by this system in PostSyncPointGroup, this one was not.
+            GetOrCreateAndAddUnmanagedSystem<InitializeAnimatedBuffersSystem>();
         }
     }
 


### PR DESCRIPTION
Disclosure: AI-assisted, but I've verified the fix and the repro myself and it looks good to me. Open to any changes

## Base of Changes

Framework **0.15.9** (`master` @ `9056ac6`, tag `v0.15.9`). Entities 1.4.7, Entities Graphics 1.4.20, Unity 6000.3.19f1, URP, D3D11, `LATIOS_TRANSFORMS_UNITY`.

Fixes #75.

## Summary

An **optimized** skeleton that is bound at Kinemation's **render sync point** (rather than the frame sync point) — e.g. one instantiated at runtime and rendered the same frame, or a Netcode-for-Entities ghost — reaches `SkinningDispatchSystem` **before its compressed `OptimizedBoneTransform` buffer has been expanded** from `boneCount` to `boneCount * 6`. `ProcessOptimized` then reads `boneCount = bonesFullBuffer.Length / 6` (too small) and over-indexes the bone array on the virtual-mesh offset path, corrupting the skinning upload. In-editor this is a **hard D3D11 device-reset crash** (`Failed to present D3D11 swapchain due to device reset/removed`); with the Jobs Debugger on it surfaces first as `IndexOutOfRangeException: Index 22 is out of range of '8' Length` at `SkinningDispatchSystem.cs:2281`.

The fix runs `InitializeAnimatedBuffersSystem` after `KinemationBindingReactiveSystem` at the render sync point too, mirroring the frame sync point.

## Minimal repro

A self-contained project (Unity 6000.3.19f1, URP, **no Netcode**): **https://github.com/kripergvg/latios-crash-repro**

- **`crash`** branch — stock Latios 0.15.9 (from OpenUPM). Open `Assets/Repro/Repro.unity`, enter Play → the editor device-resets within seconds.
- **`no-crash`** branch — the same project with this one-line fix applied (embedded patched Latios; see the branch's `FIX.md`). Enter Play → the skeletons spawn and render with no errors and no crash.

The repro instantiates a baked optimized-skeleton prefab from a system in `PresentationSystemGroup` (so it is bound at the render sync point and skinned the same frame, before the next frame's `PostSyncPointGroup` init). Stack on the `crash` branch:

```
System.IndexOutOfRangeException: Index 22 is out of range of '8' Length.
  Latios.Kinemation.Systems.SkinningDispatchSystem.WriteBuffersJob.ProcessOptimized (SkinningDispatchSystem.cs:2281)
  Latios.Kinemation.Systems.SkinningDispatchSystem.WriteBuffersJob.Execute (SkinningDispatchSystem.cs:2006)

System.ArgumentOutOfRangeException: length
  Latios.Kinemation.Systems.SkinningDispatchSystem.GenerateSkinningCommandsJob.ProcessRequests (SkinningDispatchSystem.cs:1024)

d3d11: failed to create buffer (target 0x200 mode 0 size 48) [0x887A0005]
Crash!!!   ...GfxDeviceD3D11Base   (device reset)
```

(`size 48` = `8 * 6` — the too-small bone count reaching the GPU.) I originally hit this with Netcode ghosts (initial players/enemies at connect, and again on wave spawns), then reduced it to the Netcode-free repro above.

## Root cause

`KinemationBindingReactiveSystem` runs at **two** sync points so late/runtime-instantiated skeletons are bound before rendering:

- the **frame** sync point — `KinemationFrameSyncPointSuperSystem`, in `LatiosWorldSyncGroup`
- the **render** sync point — `KinemationRenderSyncPointSuperSystem`, in `StructuralChangePresentationSystemGroup`

But `InitializeAnimatedBuffersSystem` — which expands the compressed `OptimizedBoneTransform` buffer — only runs in `PostSyncPointGroup`, i.e. after the **frame** sync point. The render sync point had no equivalent initialization pass.

So a skeleton first bound at the render sync point still has its baked, compressed buffer (`Length == boneCount`) when the culling/skinning dispatch runs. `ProcessOptimized` computes `boneCount = Length / 6` (e.g. `53 / 6 = 8`) and, on the virtual-mesh path, does `bones[offsets[i]]` where `offsets[i]` is a real skeleton bone index (e.g. `22`) → out of range. The existing `meshBones > skeletonBonesCount` guard in `ProcessRequests` does not prevent it (the compressed skeleton *looks* like it merely "does not have enough bones", so it logs that false positive and mis-handles the request).

## The fix

Add `InitializeAnimatedBuffersSystem` to `KinemationRenderSyncPointSuperSystem`, right after `KinemationBindingReactiveSystem`, so any optimized skeleton bound at the render sync point is expanded before it is skinned — exactly as the frame sync point is already followed by that system in `PostSyncPointGroup`:

```csharp
public partial class KinemationRenderSyncPointSuperSystem : SuperSystem
{
    protected override void CreateSystems()
    {
        EnableSystemSorting = false;
        GetOrCreateAndAddUnmanagedSystem<LatiosUpdateEntitiesGraphicsChunkStructureSystem>();
        GetOrCreateAndAddUnmanagedSystem<LatiosAddWorldAndChunkRenderBoundsSystem>();
        GetOrCreateAndAddUnmanagedSystem<KinemationBindingReactiveSystem>();
        GetOrCreateAndAddUnmanagedSystem<InitializeAnimatedBuffersSystem>(); // <-- added
    }
}
```

`InitializeAnimatedBuffersSystem` is idempotent (it only rewrites buffers whose length is not already `boneCount * 6`, gated on `chunk.DidOrderChange`), so running it at both sync points adds no work in the common case where the frame sync point already handled the skeleton.

## Testing

In the repro (Unity 6000.3.19f1, URP/D3D11, `LATIOS_TRANSFORMS_UNITY`): **before** the change, entering Play device-resets the editor within seconds. **After** the change, the run is completely clean — thousands of runtime-instantiated skeletons bind, expand, and render with **no errors and no crash** (the `IndexOutOfRange`, the `ArgumentOutOfRange`, and the `does not have enough bones` false positives all disappear). Also verified in the original Netcode-for-Entities project across connect and multiple wave spawns.

## Review Items

- [x] Regression concerns — the added system runs at an existing sync super system with `EnableSystemSorting = false`; it is idempotent and mirrors the established two-sync-point pattern already used by `KinemationBindingReactiveSystem` / `LatiosAddWorldAndChunkRenderBoundsSystem`.

## Preferred Contributor Name

@kripergvg
