### PR TITLE
Add CustomCommandBuffer and 3 new Transforms commands using it

### DIFF
--- a/Core/Containers/CommandBuffers/CustomCommandBuffer.cs
+++ b/Core/Containers/CommandBuffers/CustomCommandBuffer.cs
@@ -1,0 +1,136 @@
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Entities;
+using Unity.Jobs;
+
+namespace Latios
+{
+    /// <summary>
+    /// A specialized command buffer for queueing custom commands implementing ICustomCommand.
+    /// </summary>
+    public struct CustomCommandBuffer<T0> : INativeDisposable where T0 : unmanaged, ICustomCommand
+    {
+        #region Structure
+        internal CustomCommandBufferUntyped m_customCommandBufferUntyped { get; private set; }
+        #endregion
+
+        #region CreateDestroy
+        public CustomCommandBuffer(AllocatorManager.AllocatorHandle allocator)
+        {
+            var commands = new FixedList64Bytes<CustomCommandBufferUntyped.CommandMeta>();
+            commands.Add(new CustomCommandBufferUntyped.CommandMeta
+            {
+                function    = CustomCommandRegistry.TypeToPointer<T0>.functionPtr.Data,
+                commandSize = UnsafeUtility.SizeOf<T0>()
+            });
+            m_customCommandBufferUntyped = new CustomCommandBufferUntyped(allocator, commands);
+        }
+
+        public JobHandle Dispose(JobHandle inputDeps) => m_customCommandBufferUntyped.Dispose(inputDeps);
+        public void Dispose() => m_customCommandBufferUntyped.Dispose();
+        #endregion
+
+        #region PublicAPI
+        public void Add(T0 c0, int sortKey = int.MaxValue)
+        {
+            m_customCommandBufferUntyped.Add(c0, sortKey);
+        }
+
+        public void Playback(EntityManager entityManager)
+        {
+            m_customCommandBufferUntyped.Playback(entityManager);
+        }
+
+        public int Count() => m_customCommandBufferUntyped.Count();
+
+        public ParallelWriter AsParallelWriter()
+        {
+            return new ParallelWriter(m_customCommandBufferUntyped);
+        }
+        #endregion
+
+        #region ParallelWriter
+        public struct ParallelWriter
+        {
+            private CustomCommandBufferUntyped.ParallelWriter m_customCommandBufferUntyped;
+
+            internal ParallelWriter(CustomCommandBufferUntyped ccb)
+            {
+                m_customCommandBufferUntyped = ccb.AsParallelWriter();
+            }
+
+            public void Add(T0 c0, int sortKey)
+            {
+                m_customCommandBufferUntyped.Add(c0, sortKey);
+            }
+        }
+        #endregion
+    }
+
+    /// <summary>
+    /// A specialized command buffer for queueing custom commands implementing ICustomCommand.
+    /// </summary>
+    public struct CustomCommandBuffer<T0, T1> : INativeDisposable where T0 : unmanaged, ICustomCommand where T1 : unmanaged, ICustomCommand
+    {
+        #region Structure
+        internal CustomCommandBufferUntyped m_customCommandBufferUntyped { get; private set; }
+        #endregion
+
+        #region CreateDestroy
+        public CustomCommandBuffer(AllocatorManager.AllocatorHandle allocator)
+        {
+            var commands = new FixedList64Bytes<CustomCommandBufferUntyped.CommandMeta>();
+            commands.Add(new CustomCommandBufferUntyped.CommandMeta
+            {
+                function = CustomCommandRegistry.TypeToPointer<T0>.functionPtr.Data,
+                commandSize = UnsafeUtility.SizeOf<T0>()
+            });
+            commands.Add(new CustomCommandBufferUntyped.CommandMeta
+            {
+                function = CustomCommandRegistry.TypeToPointer<T1>.functionPtr.Data,
+                commandSize = UnsafeUtility.SizeOf<T1>()
+            });
+            m_customCommandBufferUntyped = new CustomCommandBufferUntyped(allocator, commands);
+        }
+
+        public JobHandle Dispose(JobHandle inputDeps) => m_customCommandBufferUntyped.Dispose(inputDeps);
+        public void Dispose() => m_customCommandBufferUntyped.Dispose();
+        #endregion
+
+        #region PublicAPI
+        public void Add(T0 c0, T1 c1, int sortKey = int.MaxValue)
+        {
+            m_customCommandBufferUntyped.Add(c0, c1, sortKey);
+        }
+
+        public void Playback(EntityManager entityManager)
+        {
+            m_customCommandBufferUntyped.Playback(entityManager);
+        }
+
+        public int Count() => m_customCommandBufferUntyped.Count();
+
+        public ParallelWriter AsParallelWriter()
+        {
+            return new ParallelWriter(m_customCommandBufferUntyped);
+        }
+        #endregion
+
+        #region ParallelWriter
+        public struct ParallelWriter
+        {
+            private CustomCommandBufferUntyped.ParallelWriter m_customCommandBufferUntyped;
+
+            internal ParallelWriter(CustomCommandBufferUntyped ccb)
+            {
+                m_customCommandBufferUntyped = ccb.AsParallelWriter();
+            }
+
+            public void Add(T0 c0, T1 c1, int sortKey)
+            {
+                m_customCommandBufferUntyped.Add(c0, c1, sortKey);
+            }
+        }
+        #endregion
+    }
+}

--- a/Core/Containers/CommandBuffers/CustomCommandBuffer.cs.meta
+++ b/Core/Containers/CommandBuffers/CustomCommandBuffer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c547346d04d60d4186ad97cc6695f28

--- a/Core/Containers/CommandBuffers/ICustomCommand.cs
+++ b/Core/Containers/CommandBuffers/ICustomCommand.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using Latios.Unsafe;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Entities;
+using Unity.Mathematics;
+
+namespace Latios
+{
+    /// <summary>
+    /// A struct implementing this type can be used in a CustomCommandBuffer to provide custom
+    /// logic during playback on the main thread.
+    /// To create your own type, implement the interface and provide a custom Burst function pointer.
+    /// Don't forget to add the [BurstCompile] and [MonoPInvokeCallback] attributes to the static method.
+    /// </summary>
+    public interface ICustomCommand
+    {
+        public struct Context
+        {
+            /// <summary>
+            /// An EntityManager to use for processing commands.
+            /// </summary>
+            public EntityManager entityManager { get; internal set; }
+            /// <summary>
+            /// Total number of commands of this payload type being played back.
+            /// </summary>
+            public int count { get; internal set; }
+
+            internal NativeArray<UnsafeIndexedBlockList.ElementPtr> dataPtrs;
+            internal int                                            commandOffset;
+            internal int                                            expectedSize;
+
+            /// <summary>
+            /// Reads the command corresponding to the specified index.
+            /// The type should be of this particular type of ICustomCommand,
+            /// or a size-aliasable equivalent.
+            /// </summary>
+            public unsafe T ReadCommand<T>(int index) where T : unmanaged, ICustomCommand
+            {
+                CheckTypeAccess<T>(expectedSize);
+                var ptr = dataPtrs[index].ptr + commandOffset;
+                UnsafeUtility.CopyPtrToStructure<T>(ptr, out var result);
+                return result;
+            }
+
+            [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+            void CheckTypeAccess<T>(int expectedSize) where T : unmanaged, ICustomCommand
+            {
+                if (UnsafeUtility.SizeOf<T>() != expectedSize)
+                    throw new InvalidOperationException($"Attempted to access a type of size {UnsafeUtility.SizeOf<T>()} when the stored command type is of size {expectedSize}");
+            }
+        }
+
+        public delegate void OnPlayback(ref Context context);
+
+        /// <summary>
+        /// This is called once on application startup on a defaulted instance outside of Burst.
+        /// This method should define either a Burst-compiled function pointer or a managed function pointer
+        /// that will be invoked once per playback of a CustomCommandBuffer variant containing
+        /// the implementing type of ICustomCommand.
+        /// </summary>
+        /// <returns></returns>
+        public FunctionPointer<OnPlayback> GetFunctionPointer();
+    }
+
+    internal static class CustomCommandRegistry
+    {
+        struct SharedKey { }
+
+        public struct TypeToPointer<T> where T : unmanaged, ICustomCommand
+        {
+            public static readonly SharedStatic< FunctionPointer<ICustomCommand.OnPlayback> > functionPtr =
+                SharedStatic< FunctionPointer<ICustomCommand.OnPlayback> >.GetOrCreate<SharedKey, T>();
+        }
+
+        static FunctionPointer<ICustomCommand.OnPlayback> GetFunctionPtr<T>() where T : unmanaged, ICustomCommand
+        {
+            T t = default;
+            return t.GetFunctionPointer();
+        }
+
+        static void InitCommands(IEnumerable<Type> types)
+        {
+            var method  = typeof(CustomCommandRegistry).GetMethod(nameof(GetFunctionPtr), BindingFlags.Static | BindingFlags.NonPublic);
+            var keyType = typeof(SharedKey);
+
+            foreach (var type in types)
+            {
+                if (type.IsGenericType || type.IsInterface)
+                    continue;
+
+                var generic     = method.MakeGenericMethod(type);
+                var functionPtr = (FunctionPointer<ICustomCommand.OnPlayback>)generic.Invoke(
+                    null,
+                    null);
+                SharedStatic<FunctionPointer<ICustomCommand.OnPlayback> >.GetOrCreate(keyType, type).Data = functionPtr;
+            }
+        }
+
+#if UNITY_EDITOR
+        [UnityEditor.InitializeOnLoadMethod]
+        static void InitEditor()
+        {
+            var commandTypes = UnityEditor.TypeCache.GetTypesDerivedFrom<ICustomCommand>();
+
+            InitCommands(commandTypes);
+        }
+#else
+        [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.AfterAssembliesLoaded)]
+#endif
+        internal static void InitRuntime()
+        {
+            var commandTypes = new List<Type>();
+            var commandType  = typeof(ICustomCommand);
+            var coreAssembly = commandType.Assembly;
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (!BootstrapTools.IsAssemblyReferencingOtherAssembly(assembly, coreAssembly))
+                    continue;
+
+                try
+                {
+                    var assemblyTypes = assembly.GetTypes();
+                    foreach (var t in assemblyTypes)
+                    {
+                        if (commandType.IsAssignableFrom(t))
+                            commandTypes.Add(t);
+                    }
+                }
+                catch (ReflectionTypeLoadException e)
+                {
+                    foreach (var t in e.Types)
+                    {
+                        if (t != null && commandType.IsAssignableFrom(t))
+                            commandTypes.Add(t);
+                    }
+
+                    UnityEngine.Debug.LogWarning($"Core ICustomCommand.cs failed loading assembly: {(assembly.IsDynamic ? assembly.ToString() : assembly.Location)}");
+                }
+            }
+
+            InitCommands(commandTypes);
+        }
+    }
+}

--- a/Core/Containers/CommandBuffers/ICustomCommand.cs.meta
+++ b/Core/Containers/CommandBuffers/ICustomCommand.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f6e802433c009a94ba7bfe7e3f94df1f

--- a/Core/Framework/LatiosWorldUnmanaged.cs
+++ b/Core/Framework/LatiosWorldUnmanaged.cs
@@ -876,7 +876,7 @@ namespace Latios
         public ref Systems.TickedSyncPointPlaybackSystem GetTickedSyncPoint()
         {
 #if ENABLE_UNITY_COLLECTIONS_CHECKS
-            if (m_syncPointPlaybackSystem == null)
+            if (m_tickedSyncPointPlaybackSystem == null)
                 throw new System.InvalidOperationException("No TickedSyncPointPlaybackSystem exists in the LatiosWorld. You may need to install ticking in the bootstrap.");
 #endif
             return ref *m_tickedSyncPointPlaybackSystem;

--- a/Core/Internal/CustomCommandBufferUntyped.cs
+++ b/Core/Internal/CustomCommandBufferUntyped.cs
@@ -1,0 +1,354 @@
+using System;
+using System.Diagnostics;
+using Latios.Unsafe;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Entities;
+using Unity.Jobs;
+using Unity.Mathematics;
+
+using CommandFunction = Unity.Burst.FunctionPointer<Latios.ICustomCommand.OnPlayback>;
+
+namespace Latios
+{
+    [NativeContainer]
+    [BurstCompile]
+    internal unsafe struct CustomCommandBufferUntyped : INativeDisposable
+    {
+        #region Structure
+        [NativeDisableUnsafePtrRestriction] private UnsafeParallelBlockList<int>*     m_sortKeyBlockList;
+        [NativeDisableUnsafePtrRestriction] private UnsafeParallelBlockList*         m_dataBlockList;
+        [NativeDisableUnsafePtrRestriction] private State*                           m_state;
+
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+        AtomicSafetyHandle m_Safety;
+
+        static readonly SharedStatic<int> s_staticSafetyId = SharedStatic<int>.GetOrCreate<CustomCommandBufferUntyped>();
+#endif
+
+        private struct State
+        {
+            public FixedList64Bytes<CommandFunction> commandFunctions;
+            public FixedList64Bytes<int>             commandSizes;
+            public AllocatorManager.AllocatorHandle  allocator;
+            public bool                              playedBack;
+        }
+
+        internal struct SortKey : IRadixSortableInt
+        {
+            public int sortKey;
+
+            public int GetKey() => sortKey;
+        }
+
+        internal struct CommandMeta
+        {
+            public CommandFunction function;
+            public int             commandSize;
+        }
+        #endregion
+
+        #region CreateDestroy
+        public CustomCommandBufferUntyped(AllocatorManager.AllocatorHandle allocator,
+                                          FixedList64Bytes<CommandMeta>    commands = default) : this(allocator, commands, 1)
+        {
+        }
+
+        internal CustomCommandBufferUntyped(AllocatorManager.AllocatorHandle allocator,
+                                            FixedList64Bytes<CommandMeta>    commands,
+                                            int                              disposeSentinelStackDepth)
+        {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            CheckAllocator(allocator);
+
+            m_Safety = CollectionHelper.CreateSafetyHandle(allocator);
+            CollectionHelper.SetStaticSafetyId<EntityOperationCommandBuffer>(ref m_Safety, ref s_staticSafetyId.Data);
+            AtomicSafetyHandle.SetBumpSecondaryVersionOnScheduleWrite(m_Safety, true);
+#endif
+
+            int                               dataPayloadSize = 0;
+            FixedList64Bytes<int>             commandSizes    = new FixedList64Bytes<int>();
+            FixedList64Bytes<CommandFunction> functions       = new FixedList64Bytes<CommandFunction>();
+            for (int i = 0; i < commands.Length; i++)
+            {
+                functions.Add(commands[i].function);
+                commandSizes.Add(commands[i].commandSize);
+                dataPayloadSize += commands[i].commandSize;
+            }
+            m_sortKeyBlockList  = AllocatorManager.Allocate<UnsafeParallelBlockList<int> >(allocator, 1);
+            m_dataBlockList     = AllocatorManager.Allocate<UnsafeParallelBlockList>(allocator, 1);
+            m_state             = AllocatorManager.Allocate<State>(allocator, 1);
+            *m_sortKeyBlockList = new UnsafeParallelBlockList<int>(256, allocator);
+            *m_dataBlockList    = new UnsafeParallelBlockList(dataPayloadSize, 256, allocator);
+            *m_state            = new State
+            {
+                commandFunctions = functions,
+                commandSizes     = commandSizes,
+                allocator        = allocator,
+                playedBack       = false
+            };
+        }
+
+        [BurstCompile]
+        private struct DisposeJob : IJob
+        {
+            [NativeDisableUnsafePtrRestriction]
+            public State* state;
+
+            [NativeDisableUnsafePtrRestriction]
+            public UnsafeParallelBlockList<int>* sortKeyBlockList;
+            [NativeDisableUnsafePtrRestriction]
+            public UnsafeParallelBlockList* dataBlockList;
+
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            internal AtomicSafetyHandle m_Safety;
+#endif
+
+            public void Execute()
+            {
+                Deallocate(state, sortKeyBlockList, dataBlockList);
+            }
+        }
+
+        public JobHandle Dispose(JobHandle inputDeps)
+        {
+            var jobHandle = new DisposeJob
+            {
+                sortKeyBlockList = m_sortKeyBlockList,
+                dataBlockList    = m_dataBlockList,
+                state            = m_state,
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+                m_Safety = m_Safety
+#endif
+            }.Schedule(inputDeps);
+
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            AtomicSafetyHandle.Release(m_Safety);
+#endif
+            m_state            = null;
+            m_dataBlockList    = null;
+            m_sortKeyBlockList = null;
+            return jobHandle;
+        }
+
+        public void Dispose()
+        {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            CollectionHelper.DisposeSafetyHandle(ref m_Safety);
+#endif
+            Deallocate(m_state, m_sortKeyBlockList, m_dataBlockList);
+        }
+
+        private static void Deallocate(State* state, UnsafeParallelBlockList<int>* sortKeyBlockList, UnsafeParallelBlockList* dataBlockList)
+        {
+            var allocator = state->allocator;
+            sortKeyBlockList->Dispose();
+            dataBlockList->Dispose();
+            AllocatorManager.Free(allocator, sortKeyBlockList, 1);
+            AllocatorManager.Free(allocator, dataBlockList,    1);
+            AllocatorManager.Free(allocator, state,            1);
+        }
+        #endregion
+
+        #region API
+        [WriteAccessRequired]
+        public void Add<T0>(T0 c0, int sortKey = int.MaxValue) where T0 : unmanaged
+        {
+            CheckWriteAccess();
+            CheckHasNotPlayedBack();
+            m_sortKeyBlockList->Write(sortKey, 0);
+            byte* ptr = (byte*)m_dataBlockList->Allocate(0);
+            UnsafeUtility.CopyStructureToPtr(ref c0, ptr);
+        }
+
+        [WriteAccessRequired]
+        public void Add<T0, T1>(T0 c0, T1 c1, int sortKey = int.MaxValue) where T0 : unmanaged where T1 : unmanaged
+        {
+            CheckWriteAccess();
+            CheckHasNotPlayedBack();
+            m_sortKeyBlockList->Write(sortKey, 0);
+            byte* ptr = (byte*)m_dataBlockList->Allocate(0);
+            UnsafeUtility.CopyStructureToPtr(ref c0, ptr);
+            ptr += m_state->commandSizes[0];
+            UnsafeUtility.CopyStructureToPtr(ref c1, ptr);
+        }
+
+        public int Count()
+        {
+            CheckReadAccess();
+            return m_sortKeyBlockList->Count();
+        }
+
+        public void Playback(EntityManager entityManager)
+        {
+            CheckWriteAccess();
+            CheckHasNotPlayedBack();
+            Playbacker.Playback((CustomCommandBufferUntyped*)UnsafeUtility.AddressOf(ref this), (EntityManager*)UnsafeUtility.AddressOf(ref entityManager));
+        }
+
+        public ParallelWriter AsParallelWriter()
+        {
+            var writer = new ParallelWriter(m_sortKeyBlockList, m_dataBlockList, m_state);
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            writer.m_Safety = m_Safety;
+            CollectionHelper.SetStaticSafetyId<ParallelWriter>(ref writer.m_Safety, ref ParallelWriter.s_staticSafetyId.Data);
+#endif
+            return writer;
+        }
+        #endregion
+
+        #region Implementation
+        [BurstCompile]
+        static class Playbacker
+        {
+            [BurstCompile]
+            public static void Playback(CustomCommandBufferUntyped* ccb, EntityManager* em)
+            {
+                PlaybackOnThread(*ccb, *em);
+            }
+
+            static void PlaybackOnThread(CustomCommandBufferUntyped ccb, EntityManager em)
+            {
+                int count = ccb.Count();
+                if (count == 0)
+                    return;
+
+                var sortKeyArray = new NativeArray<int>(count, Allocator.Temp, NativeArrayOptions.UninitializedMemory);
+                ccb.m_sortKeyBlockList->GetElementValues(sortKeyArray);
+
+                var unsortedDataPtrs = new NativeArray<UnsafeIndexedBlockList.ElementPtr>(count, Allocator.Temp, NativeArrayOptions.UninitializedMemory);
+                ccb.m_dataBlockList->GetElementPtrs(unsortedDataPtrs);
+
+                var ranks = new NativeArray<int>(count, Allocator.Temp, NativeArrayOptions.UninitializedMemory);
+                RadixSort.RankSortInt(ranks, sortKeyArray.Reinterpret<SortKey>());
+
+                var sortedDataPtrs = new NativeArray<UnsafeIndexedBlockList.ElementPtr>(count, Allocator.Temp, NativeArrayOptions.UninitializedMemory);
+                for (int i = 0; i < count; i++)
+                {
+                    sortedDataPtrs[i] = unsortedDataPtrs[ranks[i]];
+                }
+
+                int commandOffset = 0;
+                for (int i = 0; i < ccb.m_state->commandFunctions.Length; i++)
+                {
+                    var commandSize = ccb.m_state->commandSizes[i];
+                    var context     = new ICustomCommand.Context
+                    {
+                        entityManager = em,
+                        count         = count,
+                        dataPtrs      = sortedDataPtrs,
+                        commandOffset = commandOffset,
+                        expectedSize  = commandSize,
+                    };
+                    ccb.m_state->commandFunctions[i].Invoke(ref context);
+                    commandOffset += commandSize;
+                }
+
+                ccb.m_state->playedBack = true;
+            }
+        }
+        #endregion
+
+        #region Checks
+        [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+        void CheckWriteAccess()
+        {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            AtomicSafetyHandle.CheckWriteAndThrow(m_Safety);
+#endif
+        }
+
+        [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+        void CheckReadAccess()
+        {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            AtomicSafetyHandle.CheckReadAndThrow(m_Safety);
+#endif
+        }
+
+        [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+        void CheckHasNotPlayedBack()
+        {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            if (m_state->playedBack)
+                throw new InvalidOperationException("CustomCommandBuffer has already been played back.");
+#endif
+        }
+
+        [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+        static void CheckAllocator(AllocatorManager.AllocatorHandle allocator)
+        {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            if (allocator.ToAllocator <= Allocator.None)
+                throw new System.InvalidOperationException("Allocator cannot be Invalid or None");
+#endif
+        }
+        #endregion
+
+        #region ParallelWriter
+        [NativeContainer]
+        [NativeContainerIsAtomicWriteOnly]
+        public struct ParallelWriter
+        {
+            [NativeDisableUnsafePtrRestriction] private UnsafeParallelBlockList<int>*    m_sortKeyBlockList;
+            [NativeDisableUnsafePtrRestriction] private UnsafeParallelBlockList*         m_dataBlockList;
+            [NativeDisableUnsafePtrRestriction] private State*                           m_state;
+            [NativeSetThreadIndex] private int                                           m_ThreadIndex;
+
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            internal AtomicSafetyHandle m_Safety;
+            internal static readonly SharedStatic<int> s_staticSafetyId = SharedStatic<int>.GetOrCreate<ParallelWriter>();
+#endif
+
+            internal ParallelWriter(UnsafeParallelBlockList<int>* sortKeyBlockList, UnsafeParallelBlockList* dataBlockList, void* state)
+            {
+                m_sortKeyBlockList = sortKeyBlockList;
+                m_dataBlockList    = dataBlockList;
+                m_state            = (State*)state;
+                m_ThreadIndex      = 0;
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+                m_Safety = default;
+#endif
+            }
+
+            public void Add<T0>(T0 c0, int sortKey) where T0 : unmanaged
+            {
+                CheckWriteAccess();
+                CheckHasNotPlayedBack();
+                m_sortKeyBlockList->Write(sortKey, m_ThreadIndex);
+                byte* ptr = (byte*)m_dataBlockList->Allocate(m_ThreadIndex);
+                UnsafeUtility.CopyStructureToPtr(ref c0, ptr);
+            }
+
+            public void Add<T0, T1>(T0 c0, T1 c1, int sortKey) where T0 : unmanaged where T1 : unmanaged
+            {
+                CheckWriteAccess();
+                CheckHasNotPlayedBack();
+                m_sortKeyBlockList->Write(sortKey, m_ThreadIndex);
+                byte* ptr = (byte*)m_dataBlockList->Allocate(m_ThreadIndex);
+                UnsafeUtility.CopyStructureToPtr(ref c0, ptr);
+                ptr += m_state->commandSizes[0];
+                UnsafeUtility.CopyStructureToPtr(ref c1, ptr);
+            }
+
+            [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+            void CheckWriteAccess()
+            {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+                AtomicSafetyHandle.CheckWriteAndThrow(m_Safety);
+#endif
+            }
+
+            [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+            void CheckHasNotPlayedBack()
+            {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+                if (m_state->playedBack)
+                    throw new InvalidOperationException("CustomCommandBuffer has already been played back.");
+#endif
+            }
+        }
+        #endregion
+    }
+}

--- a/Core/Internal/CustomCommandBufferUntyped.cs.meta
+++ b/Core/Internal/CustomCommandBufferUntyped.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e0eb3729625d7de4fa2b01ef94b109d4

--- a/Core/Systems/Ticking/TickedSyncPointPlaybackSystem.cs
+++ b/Core/Systems/Ticking/TickedSyncPointPlaybackSystem.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using Unity.Burst;
 using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
 using Unity.Entities.Exposed;
 using Unity.Jobs;
@@ -25,7 +26,7 @@ namespace Latios.Systems
 
         protected override void OnUpdate()
         {
-            ref var playbackSystemRef = ref World.Unmanaged.GetUnsafeSystemRef<SyncPointPlaybackSystem>(m_syncPointPlaybackSystem);
+            ref var playbackSystemRef = ref World.Unmanaged.GetUnsafeSystemRef<TickedSyncPointPlaybackSystem>(m_syncPointPlaybackSystem);
             var     unmanaged         = World.Unmanaged.GetLatiosWorldUnmanaged();
             do
             {
@@ -62,6 +63,7 @@ namespace Latios.Systems
             InstantiateUntyped,
             AddComponentsNoData,
             AddComponentsUntyped,
+            CustomUntyped,
         }
 
         struct PlaybackInstance
@@ -78,6 +80,7 @@ namespace Latios.Systems
         NativeList<InstantiateCommandBufferUntyped>   m_instantiateCommandBuffersUntyped;
         NativeList<AddComponentsCommandBuffer>        m_addComponentsCommandBuffersWithoutData;
         NativeList<AddComponentsCommandBufferUntyped> m_addComponentsCommandBuffersUntyped;
+        NativeList<CustomCommandBufferUntyped>        m_customCommandBuffersUntyped;
 
         NativeList<JobHandle>                m_jobHandles;
         NativeList<PlaybackInstance>         m_playbackInstances;
@@ -101,6 +104,7 @@ namespace Latios.Systems
         int m_instantiateUntypedIndex;
         int m_addComponentsNoDataIndex;
         int m_addComponentsUntypedIndex;
+        int m_customUntypedIndex;
 
         internal NativeText.ReadOnly m_requestSystemNameForCurrentBuffer;
         internal FixedString64Bytes  m_currentBufferTypeName;
@@ -129,6 +133,7 @@ namespace Latios.Systems
             m_instantiateCommandBuffersUntyped       = new NativeList<InstantiateCommandBufferUntyped>(Allocator.Persistent);
             m_addComponentsCommandBuffersWithoutData = new NativeList<AddComponentsCommandBuffer>(Allocator.Persistent);
             m_addComponentsCommandBuffersUntyped     = new NativeList<AddComponentsCommandBufferUntyped>(Allocator.Persistent);
+            m_customCommandBuffersUntyped            = new NativeList<CustomCommandBufferUntyped>(Allocator.Persistent);
 
             m_jobHandles = new NativeList<JobHandle>(Allocator.Persistent);
 
@@ -158,6 +163,7 @@ namespace Latios.Systems
             m_instantiateCommandBuffersUntyped.Dispose();
             m_addComponentsCommandBuffersWithoutData.Dispose();
             m_addComponentsCommandBuffersUntyped.Dispose();
+            m_customCommandBuffersUntyped.Dispose();
 
             m_externalSourceText.Dispose();
         }
@@ -196,6 +202,7 @@ namespace Latios.Systems
                     case PlaybackType.InstantiateUntyped: m_currentBufferTypeName   = "InstantiateCommandBuffer"; break;
                     case PlaybackType.AddComponentsNoData: m_currentBufferTypeName  = "AddComponenstCommandBuffer"; break;
                     case PlaybackType.AddComponentsUntyped: m_currentBufferTypeName = "AddComponentsCommandBuffer"; break;
+                    case PlaybackType.CustomUntyped: m_currentBufferTypeName        = "CustomCommandBuffer"; break;
                 }
                 if (state.WorldUnmanaged.IsSystemValid(instance.requestingSystem))
                     m_requestSystemNameForCurrentBuffer = state.WorldUnmanaged.ResolveSystemStateRef(instance.requestingSystem).DebugName;
@@ -266,6 +273,13 @@ namespace Latios.Systems
                         accb.Playback(state.EntityManager);
                         break;
                     }
+                    case PlaybackType.CustomUntyped:
+                    {
+                        var ccb = m_customCommandBuffersUntyped[m_customUntypedIndex];
+                        m_customUntypedIndex++;
+                        ccb.Playback(state.EntityManager);
+                        break;
+                    }
                 }
 #if ENABLE_PROFILER
                 m_currentMarker.End();
@@ -295,6 +309,7 @@ namespace Latios.Systems
             m_instantiateCommandBuffersUntyped.Clear();
             m_addComponentsCommandBuffersWithoutData.Clear();
             m_addComponentsCommandBuffersUntyped.Clear();
+            m_customCommandBuffersUntyped.Clear();
 
             m_entityIndex               = 0;
             m_enableIndex               = 0;
@@ -304,6 +319,7 @@ namespace Latios.Systems
             m_instantiateUntypedIndex   = 0;
             m_addComponentsNoDataIndex  = 0;
             m_addComponentsUntypedIndex = 0;
+            m_customUntypedIndex        = 0;
 
             m_commandBufferAllocator.Allocator.Rewind();
         }
@@ -330,6 +346,18 @@ namespace Latios.Systems
             };
             m_playbackInstances.Add(instance);
             m_addComponentsCommandBuffersUntyped.Add(accb);
+        }
+
+        internal void AddCustomCommandBufferUntyped(CustomCommandBufferUntyped ccb)
+        {
+            m_hasPendingJobHandlesToAcquire = true;
+            var instance                    = new PlaybackInstance
+            {
+                type             = PlaybackType.CustomUntyped,
+                requestingSystem = m_world.m_impl->m_worldUnmanaged.GetCurrentlyExecutingSystem()
+            };
+            m_playbackInstances.Add(instance);
+            m_customCommandBuffersUntyped.Add(ccb);
         }
 
         #endregion
@@ -552,6 +580,26 @@ namespace Latios.Systems
         }
 
         /// <summary>
+        /// Creates a new CustomCommandBuffer that will be played back by this system.
+        /// </summary>
+        public CustomCommandBuffer<T0> CreateCustomCommandBuffer<T0>() where T0 : unmanaged, ICustomCommand
+        {
+            var ccb = new CustomCommandBuffer<T0>(allocator);
+            AddCustomCommandBufferUntyped(ccb.m_customCommandBufferUntyped);
+            return ccb;
+        }
+
+        /// <summary>
+        /// Creates a new CustomCommandBuffer that will be played back by this system.
+        /// </summary>
+        public CustomCommandBuffer<T0, T1> CreateCustomCommandBuffer<T0, T1>() where T0 : unmanaged, ICustomCommand where T1 : unmanaged, ICustomCommand
+        {
+            var ccb = new CustomCommandBuffer<T0, T1>(allocator);
+            AddCustomCommandBufferUntyped(ccb.m_customCommandBufferUntyped);
+            return ccb;
+        }
+
+        /// <summary>
         /// Adds a JobHandle representing a job or set of jobs which write to a command buffer produced by this system.
         /// You do not need to call this method if the system is tracked by the LatiosWorld. However, calling this method
         /// inside a tracked system cancels automatic dependency propagation for that system for that update, which may be desirable.
@@ -737,6 +785,30 @@ namespace Latios
             var icb = new InstantiateCommandBufferCommand2<T0, T1, T2, T3, T4, T5, T6>(syncPoint.allocator);
             syncPoint.AddInstantiateCommandBufferUntyped(icb.m_instantiateCommandBufferUntyped);
             return icb;
+        }
+    }
+
+    public static class TickedSyncPointsCustomCommandExtensions
+    {
+        /// <summary>
+        /// Creates a new CustomCommandBuffer that will be played back by this system.
+        /// </summary>
+        public static CustomCommandBuffer<T0> CreateCustomCommandBuffer<T0>(this Systems.TickedSyncPointPlaybackSystem syncPoint) where T0 : unmanaged, ICustomCommand
+        {
+            var ccb = new CustomCommandBuffer<T0>(syncPoint.allocator);
+            syncPoint.AddCustomCommandBufferUntyped(ccb.m_customCommandBufferUntyped);
+            return ccb;
+        }
+
+        /// <summary>
+        /// Creates a new CustomCommandBuffer that will be played back by this system.
+        /// </summary>
+        public static CustomCommandBuffer<T0, T1> CreateCustomCommandBuffer<T0, T1>(this Systems.TickedSyncPointPlaybackSystem syncPoint) where T0 : unmanaged, ICustomCommand
+            where T1 : unmanaged, ICustomCommand
+        {
+            var ccb = new CustomCommandBuffer<T0, T1>(syncPoint.allocator);
+            syncPoint.AddCustomCommandBufferUntyped(ccb.m_customCommandBufferUntyped);
+            return ccb;
         }
     }
 }

--- a/Core/Systems/Ticking/TickedSyncPointPlaybackSystem.cs
+++ b/Core/Systems/Ticking/TickedSyncPointPlaybackSystem.cs
@@ -580,26 +580,6 @@ namespace Latios.Systems
         }
 
         /// <summary>
-        /// Creates a new CustomCommandBuffer that will be played back by this system.
-        /// </summary>
-        public CustomCommandBuffer<T0> CreateCustomCommandBuffer<T0>() where T0 : unmanaged, ICustomCommand
-        {
-            var ccb = new CustomCommandBuffer<T0>(allocator);
-            AddCustomCommandBufferUntyped(ccb.m_customCommandBufferUntyped);
-            return ccb;
-        }
-
-        /// <summary>
-        /// Creates a new CustomCommandBuffer that will be played back by this system.
-        /// </summary>
-        public CustomCommandBuffer<T0, T1> CreateCustomCommandBuffer<T0, T1>() where T0 : unmanaged, ICustomCommand where T1 : unmanaged, ICustomCommand
-        {
-            var ccb = new CustomCommandBuffer<T0, T1>(allocator);
-            AddCustomCommandBufferUntyped(ccb.m_customCommandBufferUntyped);
-            return ccb;
-        }
-
-        /// <summary>
         /// Adds a JobHandle representing a job or set of jobs which write to a command buffer produced by this system.
         /// You do not need to call this method if the system is tracked by the LatiosWorld. However, calling this method
         /// inside a tracked system cancels automatic dependency propagation for that system for that update, which may be desirable.
@@ -812,4 +792,3 @@ namespace Latios
         }
     }
 }
-

--- a/Core/Systems/_Essentials/SyncPointPlaybackSystem.cs
+++ b/Core/Systems/_Essentials/SyncPointPlaybackSystem.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using Unity.Burst;
 using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
 using Unity.Entities.Exposed;
 using Unity.Jobs;
@@ -64,6 +65,7 @@ namespace Latios.Systems
             InstantiateUntyped,
             AddComponentsNoData,
             AddComponentsUntyped,
+            CustomUntyped,
         }
 
         struct PlaybackInstance
@@ -80,6 +82,7 @@ namespace Latios.Systems
         NativeList<InstantiateCommandBufferUntyped>   m_instantiateCommandBuffersUntyped;
         NativeList<AddComponentsCommandBuffer>        m_addComponentsCommandBuffersWithoutData;
         NativeList<AddComponentsCommandBufferUntyped> m_addComponentsCommandBuffersUntyped;
+        NativeList<CustomCommandBufferUntyped>        m_customCommandBuffersUntyped;
 
         NativeList<JobHandle>                m_jobHandles;
         NativeList<PlaybackInstance>         m_playbackInstances;
@@ -103,6 +106,7 @@ namespace Latios.Systems
         int m_instantiateUntypedIndex;
         int m_addComponentsNoDataIndex;
         int m_addComponentsUntypedIndex;
+        int m_customUntypedIndex;
 
         internal NativeText.ReadOnly m_requestSystemNameForCurrentBuffer;
         internal FixedString64Bytes  m_currentBufferTypeName;
@@ -131,6 +135,7 @@ namespace Latios.Systems
             m_instantiateCommandBuffersUntyped       = new NativeList<InstantiateCommandBufferUntyped>(Allocator.Persistent);
             m_addComponentsCommandBuffersWithoutData = new NativeList<AddComponentsCommandBuffer>(Allocator.Persistent);
             m_addComponentsCommandBuffersUntyped     = new NativeList<AddComponentsCommandBufferUntyped>(Allocator.Persistent);
+            m_customCommandBuffersUntyped            = new NativeList<CustomCommandBufferUntyped>(Allocator.Persistent);
 
             m_jobHandles = new NativeList<JobHandle>(Allocator.Persistent);
 
@@ -160,6 +165,7 @@ namespace Latios.Systems
             m_instantiateCommandBuffersUntyped.Dispose();
             m_addComponentsCommandBuffersWithoutData.Dispose();
             m_addComponentsCommandBuffersUntyped.Dispose();
+            m_customCommandBuffersUntyped.Dispose();
 
             m_externalSourceText.Dispose();
         }
@@ -197,6 +203,7 @@ namespace Latios.Systems
                     case PlaybackType.InstantiateUntyped: m_currentBufferTypeName   = "InstantiateCommandBuffer"; break;
                     case PlaybackType.AddComponentsNoData: m_currentBufferTypeName  = "AddComponenstCommandBuffer"; break;
                     case PlaybackType.AddComponentsUntyped: m_currentBufferTypeName = "AddComponentsCommandBuffer"; break;
+                    case PlaybackType.CustomUntyped: m_currentBufferTypeName        = "CustomCommandBuffer"; break;
                 }
                 if (state.WorldUnmanaged.IsSystemValid(instance.requestingSystem))
                     m_requestSystemNameForCurrentBuffer = state.WorldUnmanaged.ResolveSystemStateRef(instance.requestingSystem).DebugName;
@@ -267,6 +274,13 @@ namespace Latios.Systems
                         accb.Playback(state.EntityManager);
                         break;
                     }
+                    case PlaybackType.CustomUntyped:
+                    {
+                        var ccb = m_customCommandBuffersUntyped[m_customUntypedIndex];
+                        m_customUntypedIndex++;
+                        ccb.Playback(state.EntityManager);
+                        break;
+                    }
                 }
 #if ENABLE_PROFILER
                 m_currentMarker.End();
@@ -291,6 +305,7 @@ namespace Latios.Systems
             m_instantiateCommandBuffersUntyped.Clear();
             m_addComponentsCommandBuffersWithoutData.Clear();
             m_addComponentsCommandBuffersUntyped.Clear();
+            m_customCommandBuffersUntyped.Clear();
 
             m_entityIndex               = 0;
             m_enableIndex               = 0;
@@ -300,6 +315,7 @@ namespace Latios.Systems
             m_instantiateUntypedIndex   = 0;
             m_addComponentsNoDataIndex  = 0;
             m_addComponentsUntypedIndex = 0;
+            m_customUntypedIndex        = 0;
 
             m_commandBufferAllocator.Allocator.Rewind();
         }
@@ -326,6 +342,18 @@ namespace Latios.Systems
             };
             m_playbackInstances.Add(instance);
             m_addComponentsCommandBuffersUntyped.Add(accb);
+        }
+
+        internal void AddCustomCommandBufferUntyped(CustomCommandBufferUntyped ccb)
+        {
+            m_hasPendingJobHandlesToAcquire = true;
+            var instance                    = new PlaybackInstance
+            {
+                type             = PlaybackType.CustomUntyped,
+                requestingSystem = m_world.m_impl->m_worldUnmanaged.GetCurrentlyExecutingSystem()
+            };
+            m_playbackInstances.Add(instance);
+            m_customCommandBuffersUntyped.Add(ccb);
         }
 
         #endregion
@@ -548,6 +576,26 @@ namespace Latios.Systems
         }
 
         /// <summary>
+        /// Creates a new CustomCommandBuffer that will be played back by this system.
+        /// </summary>
+        public CustomCommandBuffer<T0> CreateCustomCommandBuffer<T0>() where T0 : unmanaged, ICustomCommand
+        {
+            var ccb = new CustomCommandBuffer<T0>(allocator);
+            AddCustomCommandBufferUntyped(ccb.m_customCommandBufferUntyped);
+            return ccb;
+        }
+
+        /// <summary>
+        /// Creates a new CustomCommandBuffer that will be played back by this system.
+        /// </summary>
+        public CustomCommandBuffer<T0, T1> CreateCustomCommandBuffer<T0, T1>() where T0 : unmanaged, ICustomCommand where T1 : unmanaged, ICustomCommand
+        {
+            var ccb = new CustomCommandBuffer<T0, T1>(allocator);
+            AddCustomCommandBufferUntyped(ccb.m_customCommandBufferUntyped);
+            return ccb;
+        }
+
+        /// <summary>
         /// Adds a JobHandle representing a job or set of jobs which write to a command buffer produced by this system.
         /// You do not need to call this method if the system is tracked by the LatiosWorld. However, calling this method
         /// inside a tracked system cancels automatic dependency propagation for that system for that update, which may be desirable.
@@ -731,5 +779,28 @@ namespace Latios
             return icb;
         }
     }
-}
 
+    public static class SyncPointsCustomCommandExtensions
+    {
+        /// <summary>
+        /// Creates a new CustomCommandBuffer that will be played back by this system.
+        /// </summary>
+        public static CustomCommandBuffer<T0> CreateCustomCommandBuffer<T0>(this Systems.SyncPointPlaybackSystem syncPoint) where T0 : unmanaged, ICustomCommand
+        {
+            var ccb = new CustomCommandBuffer<T0>(syncPoint.allocator);
+            syncPoint.AddCustomCommandBufferUntyped(ccb.m_customCommandBufferUntyped);
+            return ccb;
+        }
+
+        /// <summary>
+        /// Creates a new CustomCommandBuffer that will be played back by this system.
+        /// </summary>
+        public static CustomCommandBuffer<T0, T1> CreateCustomCommandBuffer<T0, T1>(this Systems.SyncPointPlaybackSystem syncPoint) where T0 : unmanaged, ICustomCommand
+            where T1 : unmanaged, ICustomCommand
+        {
+            var ccb = new CustomCommandBuffer<T0, T1>(syncPoint.allocator);
+            syncPoint.AddCustomCommandBufferUntyped(ccb.m_customCommandBufferUntyped);
+            return ccb;
+        }
+    }
+}

--- a/Core/Systems/_Essentials/SyncPointPlaybackSystem.cs
+++ b/Core/Systems/_Essentials/SyncPointPlaybackSystem.cs
@@ -576,26 +576,6 @@ namespace Latios.Systems
         }
 
         /// <summary>
-        /// Creates a new CustomCommandBuffer that will be played back by this system.
-        /// </summary>
-        public CustomCommandBuffer<T0> CreateCustomCommandBuffer<T0>() where T0 : unmanaged, ICustomCommand
-        {
-            var ccb = new CustomCommandBuffer<T0>(allocator);
-            AddCustomCommandBufferUntyped(ccb.m_customCommandBufferUntyped);
-            return ccb;
-        }
-
-        /// <summary>
-        /// Creates a new CustomCommandBuffer that will be played back by this system.
-        /// </summary>
-        public CustomCommandBuffer<T0, T1> CreateCustomCommandBuffer<T0, T1>() where T0 : unmanaged, ICustomCommand where T1 : unmanaged, ICustomCommand
-        {
-            var ccb = new CustomCommandBuffer<T0, T1>(allocator);
-            AddCustomCommandBufferUntyped(ccb.m_customCommandBufferUntyped);
-            return ccb;
-        }
-
-        /// <summary>
         /// Adds a JobHandle representing a job or set of jobs which write to a command buffer produced by this system.
         /// You do not need to call this method if the system is tracked by the LatiosWorld. However, calling this method
         /// inside a tracked system cancels automatic dependency propagation for that system for that update, which may be desirable.

--- a/Transforms/QvvsTransforms/Writers/TransformCustomCommands.cs
+++ b/Transforms/QvvsTransforms/Writers/TransformCustomCommands.cs
@@ -1,0 +1,140 @@
+#if !LATIOS_TRANSFORMS_UNITY
+using AOT;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+
+namespace Latios.Transforms
+{
+    /// <summary>
+    /// An ICustomCommand to set the parent of an entity on the main thread.
+    /// </summary>
+    [BurstCompile]
+    public struct ParentCustomCommand : ICustomCommand
+    {
+        public ParentCustomCommand(Entity child,
+                                   Entity parent,
+                                   InheritanceFlags inheritanceFlags = InheritanceFlags.Normal,
+                                   SetParentOptions setParentOptions = SetParentOptions.AttachLinkedEntityGroup)
+        {
+            this.child            = child;
+            this.parent           = parent;
+            this.inheritanceFlags = inheritanceFlags;
+            this.options          = setParentOptions;
+        }
+
+        public Entity           child;
+        public Entity           parent;
+        public InheritanceFlags inheritanceFlags;
+        public SetParentOptions options;
+
+        public FunctionPointer<ICustomCommand.OnPlayback> GetFunctionPointer()
+        {
+            return BurstCompiler.CompileFunctionPointer<ICustomCommand.OnPlayback>(OnPlayback);
+        }
+
+        [MonoPInvokeCallback(typeof(ICustomCommand.OnPlayback))]
+        [BurstCompile]
+        static void OnPlayback(ref ICustomCommand.Context context)
+        {
+            var em = context.entityManager;
+            for (int i = 0; i < context.count; i++)
+            {
+                var command = context.ReadCommand<ParentCustomCommand>(i);
+                if (em.Exists(command.child) && em.Exists(command.parent))
+                {
+                    em.SetParent(command.child, command.parent, command.inheritanceFlags, command.options);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// An ICustomCommand to set the parent of an entity and set a new local transform
+    /// for the child entity on the main thread.
+    /// </summary>
+    [BurstCompile]
+    public struct ParentAndLocalTransformCustomCommand : ICustomCommand
+    {
+        public ParentAndLocalTransformCustomCommand(Entity child,
+                                                    Entity parent,
+                                                    TransformQvvs newLocalTransform,
+                                                    InheritanceFlags inheritanceFlags = InheritanceFlags.Normal,
+                                                    SetParentOptions setParentOptions = SetParentOptions.AttachLinkedEntityGroup)
+        {
+            this.child             = child;
+            this.parent            = parent;
+            this.newLocalTransform = newLocalTransform;
+            this.inheritanceFlags  = inheritanceFlags;
+            this.options           = setParentOptions;
+        }
+
+        public Entity           child;
+        public Entity           parent;
+        public TransformQvvs    newLocalTransform;
+        public InheritanceFlags inheritanceFlags;
+        public SetParentOptions options;
+
+        public FunctionPointer<ICustomCommand.OnPlayback> GetFunctionPointer()
+        {
+            return BurstCompiler.CompileFunctionPointer<ICustomCommand.OnPlayback>(OnPlayback);
+        }
+
+        [MonoPInvokeCallback(typeof(ICustomCommand.OnPlayback))]
+        [BurstCompile]
+        static void OnPlayback(ref ICustomCommand.Context context)
+        {
+            var em = context.entityManager;
+            for (int i = 0; i < context.count; i++)
+            {
+                var command = context.ReadCommand<ParentAndLocalTransformCustomCommand>(i);
+                if (em.Exists(command.child) && em.Exists(command.parent))
+                {
+                    em.SetParent(command.child, command.parent, command.inheritanceFlags, command.options);
+                    if (em.HasComponent<WorldTransform>(command.child))
+                        TransformTools.SetLocalTransform(command.child, in command.newLocalTransform, em);
+                    if (em.HasComponent<TickedWorldTransform>(command.child))
+                        TransformTools.SetTickedLocalTransform(command.child, in command.newLocalTransform, em);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// An ICustomCommand to remove an entity from its parent on the main thread.
+    /// </summary>
+    [BurstCompile]
+    public struct ClearParentCustomCommand : ICustomCommand
+    {
+        public ClearParentCustomCommand(Entity child, ClearParentOptions clearParentOptions = ClearParentOptions.TransferLinkedEntityGroup)
+        {
+            this.child   = child;
+            this.options = clearParentOptions;
+        }
+
+        public Entity             child;
+        public ClearParentOptions options;
+
+        public FunctionPointer<ICustomCommand.OnPlayback> GetFunctionPointer()
+        {
+            return BurstCompiler.CompileFunctionPointer<ICustomCommand.OnPlayback>(OnPlayback);
+        }
+
+        [MonoPInvokeCallback(typeof(ICustomCommand.OnPlayback))]
+        [BurstCompile]
+        static void OnPlayback(ref ICustomCommand.Context context)
+        {
+            var em = context.entityManager;
+            for (int i = 0; i < context.count; i++)
+            {
+                var command = context.ReadCommand<ClearParentCustomCommand>(i);
+                if (em.Exists(command.child))
+                {
+                    em.ClearParent(command.child, command.options);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Transforms/QvvsTransforms/Writers/TransformCustomCommands.cs.meta
+++ b/Transforms/QvvsTransforms/Writers/TransformCustomCommands.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f3ee7c0f450aba94481c5ff938d1f155


### PR DESCRIPTION
## Contribution Standard Info

### Base of Changes

Based on Latios-Framework@47c844cd5afda286f004a3d5ce31655e37c795ba

### Review Items

- [X] Regression concerns

- [X] Functional correctness (code-read only)

- [X] Use-case flexibility

- [X] Performance considerations

- [X] Naming, comprehension, and code aesthetic (aside from white-space)

## Details

- Defined `ICustomCommand` interface and `CustomCommandRegistry`
- Implemented internal `CustomCommandBufferUntyped` backed by `UnsafeParallelBlockList<int>`, although a wrapper struct was needed to implement `IRadixSortableInt` so it could be passed to `RadixSort.RankSortInt` (using `Reinterpret`)
- Added public `CustomCommandBuffer<T0>` & `CustomCommandBuffer<T0, T1>` wrappers and integrated their creation and playback into `SyncPointPlaybackSystem` and `TickedSyncPointPlaybackSystem`
- Added `ParentCustomCommand`, `ParentAndLocalTransformCustomCommand`, and `ClearParentCustomCommand` to QVVS Transforms using this new command buffer to queue entity hierarchy manipulations from jobs
- Manually tested basic entity reparenting in a real project, but deep edge-case testing for complex hierarchy setups hasn't been done
- Drive-by fixed some minor copy/paste bugs where Sync Point was used instead of Ticked Sync Point
